### PR TITLE
Fixes package.json to comply with packag.json specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "version": "0.1.0",
   "homepage": "https://github.com/singlecomm/angular-picker",
   "description": "An item-picking component for AngularJS.",
-  "main": [
-    "dist/angular-picker.min.js",
-    "dist/angular-picker.min.css"
-  ],
+  "main": "dist/angular-picker.min.js",
   "keywords": [
     "angular",
     "angularjs",


### PR DESCRIPTION
According to the package.json spec the `main` property should be a string and not an array.  This is necessary so that npm doesn't complain.
Reference: https://docs.npmjs.com/files/package.json#main
